### PR TITLE
Fix clis

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -9,6 +9,7 @@ import os
 # Get the list of coins
 
 home = os.path.expanduser('~')
+script_path = os.path.realpath(os.path.dirname(__file__))
 
 with open(f'assetchains.json') as file:
     assetchains = json.load(file)
@@ -152,7 +153,7 @@ def get_data_path(coin, container=True):
 
 
 def get_debug_file(coin, container=True) -> str:
-    path = get_data_path(coin)
+    path = get_data_path(coin, container)
     if container:
         path = path.replace(home, "/home/komodian")
     return f"{path}/debug.log"
@@ -245,7 +246,7 @@ def create_cli_wrappers():
             cli = f"komodo-cli"
         with open(wrapper, 'w') as conf:
             conf.write('#!/bin/bash\n')
-            conf.write(f'docker compose run {coin.lower()} {cli} "$@"\n')
+            conf.write(f'docker compose -f {script_path}/docker-compose.yml run {coin.lower()} {cli} "$@"\n')
             os.chmod(wrapper, 0o755)
 
 

--- a/configure.py
+++ b/configure.py
@@ -241,12 +241,9 @@ def create_cli_wrappers():
             wrapper = f"cli_wrappers/{coin.lower}-cli"
         else:
             wrapper = f"cli_wrappers/{cli}"
-        # This is messy, but it works. Will make it cleaner later
-        if coin == 'KMD_3P':
-            cli = f"komodo-cli"
         with open(wrapper, 'w') as conf:
             conf.write('#!/bin/bash\n')
-            conf.write(f'docker compose -f {script_path}/docker-compose.yml run {coin.lower()} {cli} "$@"\n')
+            conf.write(f'komodo-cli -conf={get_conf_file(coin, False)} "$@"\n')
             os.chmod(wrapper, 0o755)
 
 


### PR DESCRIPTION
After removing 3P cli binaries from host for security, wrappers were unresponsive. Could be due to `entrypoint` vs `command`, but those changes may cause other issues. 
As a temporary measure, Ive highjacked komodo-cli which resides on the host, usinf `-conf` to point to 3p conf files. 
Alright says may have some unintended effects with response param data types, as he experienced with verus.

An alternative is to call the docker container directly like `docker exec -it notary_docker_3p-mcl-1 komodo-cli -ac_name=MCL getinfo` or `docker exec -it notary_docker_3p-vrsc-1 verus-cli  getinfo` as long as we can ensure the container name remains static.