### PR TITLE
rm -it flags for docker exec

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -295,9 +295,9 @@ def create_cli_wrappers():
         else:
             wrapper = f"cli_wrappers/{cli}"
         with open(wrapper, 'w') as conf:
-            # docker exec -it notary_docker_3p-vrsc-1 verus-cli  getinfo
+            # docker exec notary_docker_3p-vrsc-1 verus-cli  getinfo
             conf.write('#!/bin/bash\n')
-            conf.write(f'docker exec -it {coin.lower()} {get_cli_command(coin, True)} "$@"\n')
+            conf.write(f'docker exec {coin.lower()} {get_cli_command(coin, True)} "$@"\n')
             # conf.write(f'komodo-cli -conf={get_conf_file(coin, False)} "$@"\n')
             os.chmod(wrapper, 0o755)
 


### PR DESCRIPTION
commands `docker exec` with `-it` flags will not work not from terminal (e.g. bash script) with such error `the input device is not a TTY`

e.g. https://stackoverflow.com/questions/43099116/error-the-input-device-is-not-a-tty

this change allows to use bash scripts splitters crontab setup (for fresh setup, if configs already generated then modifications of files in `notary_docker_3p/docker_files/launch_files` is needed)