### PR TITLE
replace hard-coded `/home` paths with `~`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When there is an update to any daemon repository, we need to update our `docker-
 
 ---
 ### To use cli commands
-Wrapper scripts for all CLI commands are automatically created and linked to `/home/${USER}/.local/bin` when the docker containers are built. This allows you to run commands like `mcl-cli getinfo` from anywhere on the host machine.
+Wrapper scripts for all CLI commands are automatically created and linked to `~/.local/bin` when the docker containers are built. This allows you to run commands like `mcl-cli getinfo` from anywhere on the host machine.
 
 
 ### AtomicDEX Seed Node

--- a/link_clis.sh
+++ b/link_clis.sh
@@ -3,37 +3,37 @@
 script_path=$(dirname $(realpath $0))
 
 # AYA
-rm -f /home/$USER/.aryacoin/aryacoin-cli
-ln -sf ${script_path}/cli_wrappers/aryacoin-cli /home/$USER/.local/bin/aryacoin-cli
-ln -sf ${script_path}/cli_wrappers/aryacoin-cli /home/$USER/.local/bin/aya-cli
+rm -f ~/.aryacoin/aryacoin-cli
+ln -sf ${script_path}/cli_wrappers/aryacoin-cli ~/.local/bin/aryacoin-cli
+ln -sf ${script_path}/cli_wrappers/aryacoin-cli ~/.local/bin/aya-cli
 
 # CHIPS
-rm -f /home/$USER/.chips/chips-cli
-ln -sf ${script_path}/cli_wrappers/chips-cli /home/$USER/.local/bin/chips-cli
+rm -f ~/.chips/chips-cli
+ln -sf ${script_path}/cli_wrappers/chips-cli ~/.local/bin/chips-cli
 
 # EMC2
-rm -f /home/$USER/.einsteinium/einsteinium-cli
-ln -sf ${script_path}/cli_wrappers/emc-cli /home/$USER/.local/bin/emc-cli
-ln -sf ${script_path}/cli_wrappers/emc-cli /home/$USER/.local/bin/einsteinium-cli
+rm -f ~/.einsteinium/einsteinium-cli
+ln -sf ${script_path}/cli_wrappers/emc-cli ~/.local/bin/emc-cli
+ln -sf ${script_path}/cli_wrappers/emc-cli ~/.local/bin/einsteinium-cli
 
 # KMD (3P)
-rm -f /home/${USER}/.komodo_3p/komodo_3p-cli
-rm -f /home/${USER}/.komodo_3p/komodo-cli
-rm -f /home/${USER}/.komodo_3p/*-cli
-rm -f /home/${USER}/.komodo/*-cli
-ln -sf ${script_path}/cli_wrappers/komodo_3p-cli /home/$USER/.local/bin/komodo_3p-cli
-ln -sf ${script_path}/cli_wrappers/komodo_3p-cli /home/$USER/.local/bin/kmd_3p-cli
+rm -f ~/.komodo_3p/komodo_3p-cli
+rm -f ~/.komodo_3p/komodo-cli
+rm -f ~/.komodo_3p/*-cli
+rm -f ~/.komodo/*-cli
+ln -sf ${script_path}/cli_wrappers/komodo_3p-cli ~/.local/bin/komodo_3p-cli
+ln -sf ${script_path}/cli_wrappers/komodo_3p-cli ~/.local/bin/kmd_3p-cli
 
 # MCL
-rm -f /home/${USER}/.komodo_3p/MCL/mcl-cli
-ln -sf ${script_path}/cli_wrappers/mcl-cli /home/$USER/.local/bin/mcl-cli
+rm -f ~/.komodo_3p/MCL/mcl-cli
+ln -sf ${script_path}/cli_wrappers/mcl-cli ~/.local/bin/mcl-cli
 
 # MIL
-rm -f /home/$USER/.mil/mil-cli
-ln -sf ${script_path}/cli_wrappers/mil-cli /home/$USER/.local/bin/mil-cli
+rm -f ~/.mil/mil-cli
+ln -sf ${script_path}/cli_wrappers/mil-cli ~/.local/bin/mil-cli
 
 # TOKEL
-rm -f /home/$USER/.komodo_3p/TOKEL/tokel-cli-bin
-rm -f /home/$USER/.komodo_3p/TOKEL/tokel-cli
-ln -sf ${script_path}/cli_wrappers/tokel-cli /home/$USER/.local/bin/tokel-cli
-ln -sf ${script_path}/cli_wrappers/tokel-cli /home/$USER/.local/bin/tkl-cli
+rm -f ~/.komodo_3p/TOKEL/tokel-cli-bin
+rm -f ~/.komodo_3p/TOKEL/tokel-cli
+ln -sf ${script_path}/cli_wrappers/tokel-cli ~/.local/bin/tokel-cli
+ln -sf ${script_path}/cli_wrappers/tokel-cli ~/.local/bin/tkl-cli

--- a/mm2/post-cert-renew.sh
+++ b/mm2/post-cert-renew.sh
@@ -9,8 +9,8 @@ domain="DOMAIN"
 
 sudo chown -R $user:$user /etc/letsencrypt/archive/$domain/
 sudo /usr/bin/setfacl -m "u:${user}:rx" /etc/letsencrypt/archive /etc/letsencrypt/live
-sudo cp /etc/letsencrypt/live/$domain/privkey.pem /home/$user/notary_docker_3p/mm2/$domain/privkey.pem
-sudo cp /etc/letsencrypt/live/$domain/fullchain.pem /home/$user/notary_docker_3p/mm2/$domain/fullchain.pem
-cd /home/$user/notary_docker_3p/
+sudo cp /etc/letsencrypt/live/$domain/privkey.pem ~/notary_docker_3p/mm2/$domain/privkey.pem
+sudo cp /etc/letsencrypt/live/$domain/fullchain.pem ~/notary_docker_3p/mm2/$domain/fullchain.pem
+cd ~/notary_docker_3p/
 /usr/bin/docker compose stop mm2 && /usr/bin/docker compose build mm2
 /usr/bin/docker compose up mm2 -d

--- a/setup
+++ b/setup
@@ -2,13 +2,13 @@
 
 pip3 install -r requirements.txt
 
-mkdir -p /home/${USER}/.zcash-params
+mkdir -p ~/.zcash-params
 ./fetch-params.sh
 
-source /home/${USER}/dPoW/iguana/pubkey_3p.txt
+source ~/dPoW/iguana/pubkey_3p.txt
 pubkey_3p=$pubkey
 
-source /home/${USER}/dPoW/iguana/pubkey_3p.txt
+source ~/dPoW/iguana/pubkey_3p.txt
 pubkey_main=$pubkey
 
 echo "Setting up .env file..."


### PR DESCRIPTION
Using `/home/..` paths fails for systems that are configured on `/root`.