### PR TITLE
add -ac_autosettle=0 to MCL

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -94,7 +94,7 @@ def get_launch_params(coin):
     if coin == 'KMD_3P':
         launch += " -minrelaytxfee=0.000035 -opretmintxfee=0.004 -notary"
     elif coin == 'MCL':
-        launch += " -addnode=5.189.149.242 -addnode=161.97.146.150 -addnode=149.202.158.145 -addressindex=1 -spentindex=1 -daemon"
+        launch += " -addnode=5.189.149.242 -addnode=161.97.146.150 -addnode=149.202.158.145 -addressindex=1 -spentindex=1 -ac_autosettle=0 -daemon"
 
     pubkey = get_user_pubkey()
     launch += f" -pubkey={pubkey}"

--- a/templates/docker-compose.template_3p
+++ b/templates/docker-compose.template_3p
@@ -40,7 +40,7 @@ services:
       context: ./docker_files
       dockerfile: Dockerfile.MCL
       args:
-        - COMMIT_HASH=7938b2c
+        - COMMIT_HASH=6991c03
         - USER_ID=$USER_ID
         - GROUP_ID=$GROUP_ID
         - SERVICE_CLI="mcl-cli"


### PR DESCRIPTION
closes https://github.com/KomodoPlatform/dPoW/issues/584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated launch parameters for the "MCL" coin to include a new setting.
  - Updated the Docker Compose template for the "mcl" service with a new build version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->